### PR TITLE
Fix possible NPE when "bluetoothDevice.getUUIDs()" returns null

### DIFF
--- a/app/src/main/java/com/clusterrr/sonyheadphonescontrol/TaskerFireReceiver.java
+++ b/app/src/main/java/com/clusterrr/sonyheadphonescontrol/TaskerFireReceiver.java
@@ -129,6 +129,10 @@ public final class TaskerFireReceiver extends BroadcastReceiver {
         Set<BluetoothDevice> devices = adapter.getBondedDevices();
         for (BluetoothDevice device : devices) {
             ParcelUuid[] uuids = device.getUuids();
+
+            if(uuids == null)
+                continue;
+
             for (ParcelUuid u : uuids) {
                 if (u.toString().equals(uuid.toString())) {
                     headset = device;


### PR DESCRIPTION
For whatever reason I have a Bluetooth device in my list, where `getUUIDs()` returns null.

A simple null check should fix the app crash happening because of this.